### PR TITLE
include accept in applications property of prometheus_httpd.app.src

### DIFF
--- a/src/prometheus_httpd.app.src
+++ b/src/prometheus_httpd.app.src
@@ -6,7 +6,8 @@
    [kernel,
     stdlib,
     inets,
-    prometheus
+    prometheus,
+    accept
    ]},
   {env,[]},
   {modules, []},


### PR DESCRIPTION
without it the application is not part of the release with rebar3 and
then undefined.

fix #5