### PR TITLE
Enable .ez creation via rebar3 archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ erl_crash.dump
 logs
 _build
 deps
+rebar.lock
+*.ez

--- a/rebar.config
+++ b/rebar.config
@@ -32,3 +32,5 @@
             {test, [{plugins, [{coveralls, "1.4.0"},
                                {rebar3_elvis_plugin, "0.0.4"}]},
                     {erl_opts, [nowarn_export_all]}]}]}.
+
+{plugins, [{rebar3_archive_plugin, "0.0.1"}]}.


### PR DESCRIPTION
The resulting .ez file that can be added to RabbitMQ as a plugin, which
in turn is a dependency of the enabling prometheus_rabbitmq_exporter
plugin.

The main requirement is that the Erlang version used to compile the
.beam files that end up in the .ez is the same version (or older) than
the version used to run RabbitMQ. For example, if the Erlang used to
compile is 21.0, RabbitMQ can be run on Erlang >= 21.0, but not earlier
version. The platform doesn't matter (it's OK to compile & build the .ez
on Darwin and run on Linux).

Make git ignore *.ez files