### PR TITLE
fix: Use project_plugins to avoid dep conflicts

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -29,8 +29,8 @@
                       {top_level_readme,
                        {"./README.md",
                         "https://github.com/deadtrickster/prometheus_httpd"}}]}]},
-            {test, [{plugins, [{coveralls, "1.4.0"},
+            {test, [{project_plugins, [{coveralls, "1.4.0"},
                                {rebar3_elvis_plugin, "0.0.4"}]},
                     {erl_opts, [nowarn_export_all]}]}]}.
 
-{plugins, [{rebar3_archive_plugin, "0.0.1"}]}.
+{project_plugins, [{rebar3_archive_plugin, "0.0.1"}]}.


### PR DESCRIPTION
When including project- and build-related plugins under `plugins` key in `rebar.config` there's a risk of conflict with top-level project config when lib is fetched as a dependency.

Rebar has a mechanism of `project_plugins`, where plugins are only fetched and used on same-level issue of `rebar3` command.

More info: https://rebar3.readme.io/docs/using-available-plugins#project-plugins-and-overriding-commands
Encounter: https://github.com/project-fifo/rebar3_lint/issues/42